### PR TITLE
Fixing crash if calling `resolve_absolute()` or `exists` if file doesn't exist

### DIFF
--- a/src/teenypath.cpp
+++ b/src/teenypath.cpp
@@ -462,6 +462,9 @@ namespace TeenyPath {
     path::resolve_absolute() const {
 #if defined(_POSIX_VERSION)
         std::unique_ptr<char, decltype(&std::free)> rpath(realpath(m_path.c_str(), NULL), std::free);
+        if (!rpath) {
+            return path("");
+        }
         return path(rpath.get());
 #elif defined(_WIN32)
         HANDLE hFile = CreateFile(this->wstring().c_str(),   // file to open


### PR DESCRIPTION
Hi. Thank you very much for your work! This library has saved tons of my time.
I would like to propose a possible fix of crash when `realpath` returns nullptr, usually if file doesn't exist (cannot be found using given path).
#2 